### PR TITLE
Support fr= and id= log prefixes

### DIFF
--- a/serial/serial.go
+++ b/serial/serial.go
@@ -11,8 +11,8 @@ import (
 	serial "go.bug.st/serial"
 )
 
-var nodeRe = regexp.MustCompile(`from=(0x[0-9a-fA-F]+)`)
-var fallbackRe = regexp.MustCompile(`from (0x[0-9a-fA-F]+)`)
+var nodeRe = regexp.MustCompile(`(?:from|fr|id)=(0x[0-9a-fA-F]+)`)
+var fallbackRe = regexp.MustCompile(`(?:from|fr|id) (0x[0-9a-fA-F]+)`)
 var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 // ReadLoop apre la porta seriale e legge in loop, pubblicando i pacchetti validi
@@ -89,6 +89,7 @@ func parseNodeName(line string) string {
 	}
 	return ""
 }
+
 // Send apre la porta seriale, invia i dati e chiude la porta.
 func Send(portName string, baud int, data string) error {
 	port, err := serial.Open(portName, &serial.Mode{BaudRate: baud})

--- a/serial/serial_test.go
+++ b/serial/serial_test.go
@@ -8,9 +8,12 @@ func TestParseNodeName(t *testing.T) {
 		want string
 	}{
 		{"[INF] packet from=0x1a2b seq=1", "0x1a2b"},
+		{"[INF] packet fr=0x1234 seq=1", "0x1234"},
+		{"[INF] packet id=0x4321", "0x4321"},
 		{"[DBG] other from 0xABCD tail", "0xABCD"},
+		{"[DBG] other fr 0x99AA tail", "0x99AA"},
 		{"node status from=0x0", "0x0"},
-		{"prefix from=0xDEAD data from 0xBEEF", "0xDEAD"},
+		{"prefix id=0xDEAD data fr=0xBEEF", "0xDEAD"},
 		{"garbage log line", ""},
 		{"from=nothex", ""},
 	}


### PR DESCRIPTION
## Summary
- expand node ID regexes to accept `fr=` and `id=` forms
- test additional log formats in `TestParseNodeName`

## Testing
- `go test ./...` *(fails: found packages mqtt and serial in /workspace/meshspy/serial)*

------
https://chatgpt.com/codex/tasks/task_e_686634c5271c832395ade774a21a7ef7