### PR TITLE
Send Alive message to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ docker run --device=/dev/ttyACM0 \
 
 During start-up the service prints information from `meshtastic-go` and begins
 streaming data from the serial port to the configured MQTT topic. It also
-sends a `MeshSpy Alive` message on the configured MQTT topic so other
-components can detect that the service is running.
+sends a `MeshSpy Alive` message on the configured MQTT topic and to the node
+itself using `meshtastic-go --sendtext`, so other components can detect that
+the service is running and nodes are reached.
 
 ### `start_meshspy.sh` helper
 

--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -19,7 +19,10 @@ import (
 	paho "github.com/eclipse/paho.mqtt.golang"
 )
 
-const welcomeMessage = "Ciao da MeshSpy, presto (spero) per tutti"
+const (
+	welcomeMessage = "Ciao da MeshSpy, presto (spero) per tutti"
+	aliveMessage   = "MeshSpy Alive"
+)
 
 func main() {
 	log.Println("🔥 MeshSpy avviamento iniziato...")
@@ -84,6 +87,13 @@ func main() {
 	// 📡 Attende la disponibilità della porta seriale prima di eseguire meshtastic-go
 	if err := serial.WaitForSerial(cfg.SerialPort, 30*time.Second); err != nil {
 		log.Fatalf("❌ Porta seriale %s non disponibile: %v", cfg.SerialPort, err)
+	}
+
+	// Invia un messaggio Alive anche al nodo appena la seriale è disponibile
+	if err := serial.SendTextMessage(cfg.SerialPort, aliveMessage); err != nil {
+		log.Printf("⚠️  Errore invio messaggio Alive al nodo: %v", err)
+	} else {
+		log.Printf("✅ Messaggio Alive inviato al nodo")
 	}
 
 	// 📡 Stampa info da meshtastic-go (se disponibile)


### PR DESCRIPTION
## Summary
- send the Alive message over serial once the port is ready
- document that the Alive message is also sent to the node

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686657dfe6a08323ab335c710cc651b9