### PR TITLE
Fix container cleanup in start script

### DIFF
--- a/start_meshspy.sh
+++ b/start_meshspy.sh
@@ -40,7 +40,8 @@ if [ "$CLEAN" = true ]; then
 fi
 
 # Se il container esiste già, lo rimuoviamo
-if [ $(docker ps -a -q -f name=${CONTAINER_NAME}) ]; then
+CONTAINER_ID="$(docker ps -a -q -f name=${CONTAINER_NAME})"
+if [ -n "$CONTAINER_ID" ]; then
   echo "Rimuovo il container esistente '${CONTAINER_NAME}'..."
   docker rm -f ${CONTAINER_NAME}
 fi


### PR DESCRIPTION
## Summary
- ensure `start_meshspy.sh --clean` removes any existing container

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68665a1293188323a0fa2ddb1c9b0676