### PR TITLE
Handle node names

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -14,6 +14,7 @@ import (
 
 	mqttpkg "meshspy/client"
 	"meshspy/config"
+	"meshspy/nodemap"
 	"meshspy/serial"
 
 	paho "github.com/eclipse/paho.mqtt.golang"
@@ -36,6 +37,7 @@ func main() {
 
 	// Carica la configurazione dalle variabili d'ambiente
 	cfg := config.Load()
+	nodes := nodemap.New()
 
 	// Connessione al broker MQTT
 	client, err := mqttpkg.ConnectMQTT(cfg)
@@ -132,7 +134,7 @@ func main() {
 
 	// Avvia la lettura dalla porta seriale in un goroutine
 	go func() {
-		serial.ReadLoop(cfg.SerialPort, cfg.BaudRate, cfg.Debug, func(data string) {
+		serial.ReadLoop(cfg.SerialPort, cfg.BaudRate, cfg.Debug, nodes, func(data string) {
 			// Pubblica ogni messaggio ricevuto sul topic MQTT
 			token := client.Publish(cfg.MQTTTopic, 0, false, data)
 			token.Wait()

--- a/nodemap/nodemap.go
+++ b/nodemap/nodemap.go
@@ -1,0 +1,52 @@
+package nodemap
+
+import (
+	"fmt"
+	"sync"
+
+	latestpb "meshspy/proto/latest/meshtastic"
+)
+
+type Entry struct {
+	Long  string
+	Short string
+}
+
+type Map struct {
+	mu    sync.RWMutex
+	nodes map[string]Entry
+}
+
+func New() *Map {
+	return &Map{nodes: make(map[string]Entry)}
+}
+
+func (m *Map) Update(num uint32, long, short string) {
+	id := fmt.Sprintf("0x%x", num)
+	m.mu.Lock()
+	m.nodes[id] = Entry{Long: long, Short: short}
+	m.mu.Unlock()
+}
+
+func (m *Map) UpdateFromProto(ni *latestpb.NodeInfo) {
+	if ni == nil || ni.User == nil {
+		return
+	}
+	m.Update(ni.GetNum(), ni.User.GetLongName(), ni.User.GetShortName())
+}
+
+func (m *Map) Resolve(id string) string {
+	m.mu.RLock()
+	e, ok := m.nodes[id]
+	m.mu.RUnlock()
+	if !ok {
+		return id
+	}
+	if e.Long != "" {
+		return e.Long
+	}
+	if e.Short != "" {
+		return e.Short
+	}
+	return id
+}

--- a/nodemap/nodemap_test.go
+++ b/nodemap/nodemap_test.go
@@ -1,0 +1,17 @@
+package nodemap
+
+import (
+	"fmt"
+
+	latestpb "meshspy/proto/latest/meshtastic"
+)
+
+func ExampleMap_UpdateFromProto() {
+	nm := New()
+	nm.UpdateFromProto(&latestpb.NodeInfo{
+		Num:  0x1234,
+		User: &latestpb.User{LongName: "Alice", ShortName: "A"},
+	})
+	fmt.Println(nm.Resolve("0x1234"))
+	// Output: Alice
+}


### PR DESCRIPTION
## Summary
- add a nodemap package to store node names by ID
- decode NodeInfo messages from serial and map them
- resolve node IDs to names when available

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68665d184a5083238cc2d80f95a21797