### PR TITLE
Avoid Alive message logs when disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ docker run --device=/dev/ttyACM0 \
 
 During start-up the service prints information from `meshtastic-go` and begins
 
-streaming data from the serial port to the configured MQTT topic. It also
+streaming data from the serial port to the configured MQTT topic. When the
+`SEND_ALIVE_ON_START` environment variable is set to `true`, the service also
 sends a `MeshSpy Alive` message on the configured MQTT topic and to the node
 itself using `meshtastic-go --sendtext`, so other components can detect that
 the service is running and nodes are reached.
@@ -69,6 +70,8 @@ container with some default environment variables:
 - `MQTT_USER=testmeshspy`
 - `MQTT_PASS=test1`
 - `SEND_ALIVE_ON_START=false`
+  (set to `true` if you want the service to send and log a `MeshSpy Alive`
+  message on start-up)
 
 Start the container using the defaults:
 

--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -93,11 +93,13 @@ func main() {
 		log.Fatalf("❌ Porta seriale %s non disponibile: %v", cfg.SerialPort, err)
 	}
 
-	// Invia un messaggio Alive anche al nodo appena la seriale è disponibile
-	if err := serial.SendTextMessage(cfg.SerialPort, aliveMessage); err != nil {
-		log.Printf("⚠️  Errore invio messaggio Alive al nodo: %v", err)
-	} else {
-		log.Printf("✅ Messaggio Alive inviato al nodo")
+	// Invia un messaggio Alive anche al nodo se richiesto
+	if cfg.SendAlive {
+		if err := serial.SendTextMessage(cfg.SerialPort, aliveMessage); err != nil {
+			log.Printf("⚠️  Errore invio messaggio Alive al nodo: %v", err)
+		} else {
+			log.Printf("✅ Messaggio Alive inviato al nodo")
+		}
 	}
 
 	// 📡 Stampa info da meshtastic-go (se disponibile)


### PR DESCRIPTION
## Summary
- document that sending the Alive message depends on `SEND_ALIVE_ON_START`
- only send/log the Alive message on the serial port when enabled

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68665e62d36c8323b5788a3d2414c72c