### PR TITLE
Improve serial protobuf framing

### DIFF
--- a/decoder/nodeinfo.go
+++ b/decoder/nodeinfo.go
@@ -7,19 +7,32 @@ import (
 	latestpb "meshspy/proto/latest/meshtastic"
 )
 
+const (
+	start1    = 0x94
+	start2    = 0xC3
+	headerLen = 4
+)
+
 // DecodeNodeInfo decodes a protobuf blob into a NodeInfo message.
 // Currently only the "latest" proto version is supported.
 func DecodeNodeInfo(data []byte, version string) (*latestpb.NodeInfo, error) {
+	if len(data) >= headerLen && data[0] == start1 && data[1] == start2 {
+		l := int(data[2])<<8 | int(data[3])
+		if len(data) >= headerLen+l {
+			data = data[headerLen : headerLen+l]
+		} else {
+			return nil, fmt.Errorf("incomplete frame")
+		}
+	}
 	switch version {
 	case "", "latest":
-		var ni latestpb.NodeInfo
-		if err := proto.Unmarshal(data, &ni); err == nil {
-			return &ni, nil
-		}
-		// try wrapped in FromRadio
 		var fr latestpb.FromRadio
 		if err := proto.Unmarshal(data, &fr); err == nil && fr.GetNodeInfo() != nil {
 			return fr.GetNodeInfo(), nil
+		}
+		var ni latestpb.NodeInfo
+		if err := proto.Unmarshal(data, &ni); err == nil && (ni.Num != 0 || ni.User != nil) {
+			return &ni, nil
 		}
 		return nil, fmt.Errorf("not a NodeInfo message")
 	default:

--- a/decoder/nodeinfo_test.go
+++ b/decoder/nodeinfo_test.go
@@ -24,3 +24,24 @@ func TestDecodeNodeInfo(t *testing.T) {
 		t.Fatalf("unexpected id %q", ni.GetUser().GetId())
 	}
 }
+
+func TestDecodeNodeInfoFramed(t *testing.T) {
+	orig := &pb.NodeInfo{
+		Num:  77,
+		User: &pb.User{Id: "xyz", LongName: "Bob", ShortName: "B"},
+	}
+	fr := &pb.FromRadio{PayloadVariant: &pb.FromRadio_NodeInfo{NodeInfo: orig}}
+	payload, err := proto.Marshal(fr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	header := []byte{0x94, 0xC3, byte(len(payload) >> 8), byte(len(payload))}
+	frame := append(header, payload...)
+	ni, err := DecodeNodeInfo(frame, "latest")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if ni.GetNum() != orig.GetNum() || ni.GetUser().GetId() != "xyz" {
+		t.Fatalf("unexpected result %+v", ni)
+	}
+}

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -1,7 +1,7 @@
 package serial
 
 import (
-	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -41,22 +41,22 @@ func ReadLoop(portName string, baud int, debug bool, nm *nodemap.Map, handleNode
 	}
 	defer port.Close()
 
-	reader := bufio.NewReader(port)
 	log.Printf("Listening on serial %s at %d baud", portName, baud)
 
-	var lastNode string
+	const (
+		start1    = 0x94
+		start2    = 0xC3
+		headerLen = 4
+		maxSize   = 512
+	)
 
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				continue
-			}
-			log.Printf("Serial read error: %v", err)
-			time.Sleep(time.Second)
-			continue
-		}
+	var (
+		buf      []byte
+		logBuf   bytes.Buffer
+		lastNode string
+	)
 
+	handleLine := func(line string) {
 		line = cleanLine(line)
 		if debug {
 			log.Printf("[DEBUG serial] %q", line)
@@ -71,7 +71,7 @@ func ReadLoop(portName string, baud int, debug bool, nm *nodemap.Map, handleNode
 				if debug {
 					log.Printf("[DEBUG nodemap] learned %s => %s/%s", fmt.Sprintf("0x%x", ni.GetNum()), ni.GetUser().GetLongName(), ni.GetUser().GetShortName())
 				}
-				continue
+				return
 			}
 		}
 
@@ -80,18 +80,76 @@ func ReadLoop(portName string, baud int, debug bool, nm *nodemap.Map, handleNode
 			if debug {
 				log.Printf("[DEBUG parse] no node found in %q", line)
 			}
-			continue
+			return
 		}
 		if nm != nil {
 			node = nm.Resolve(node)
 		}
 		if node == lastNode {
-			continue
+			return
 		}
 		lastNode = node
 
 		payload := fmt.Sprintf(`{"node":"%s","ts":%d}`, node, time.Now().Unix())
 		publish(payload)
+	}
+
+	for {
+		var b [1]byte
+		n, err := port.Read(b[:])
+		if err != nil {
+			if err == io.EOF {
+				continue
+			}
+			log.Printf("Serial read error: %v", err)
+			time.Sleep(time.Second)
+			continue
+		}
+		if n == 0 {
+			continue
+		}
+		buf = append(buf, b[0])
+
+		for len(buf) > 0 {
+			if len(buf) < 2 {
+				break
+			}
+			if buf[0] != start1 || buf[1] != start2 {
+				ch := buf[0]
+				buf = buf[1:]
+				if ch == '\n' {
+					handleLine(logBuf.String())
+					logBuf.Reset()
+				} else if ch != '\r' {
+					logBuf.WriteByte(ch)
+				}
+				continue
+			}
+			if len(buf) < headerLen {
+				break
+			}
+			length := int(buf[2])<<8 | int(buf[3])
+			if length <= 0 || length > maxSize {
+				buf = buf[1:]
+				continue
+			}
+			if len(buf) < headerLen+length {
+				break
+			}
+			payload := buf[headerLen : headerLen+length]
+			if nm != nil {
+				if ni, err := decoder.DecodeNodeInfo(payload, "latest"); err == nil {
+					nm.UpdateFromProto(ni)
+					if handleNodeInfo != nil {
+						handleNodeInfo(ni)
+					}
+					if debug {
+						log.Printf("[DEBUG nodemap] learned %s => %s/%s", fmt.Sprintf("0x%x", ni.GetNum()), ni.GetUser().GetLongName(), ni.GetUser().GetShortName())
+					}
+				}
+			}
+			buf = buf[headerLen+length:]
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- read raw bytes from serial port and detect protobuf frames
- allow decoder to parse frames with Meshtastic headers
- add tests for framed NodeInfo messages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68668e4232a88323816347e06f41d639