### PR TITLE
Document NODE_DB_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ container with some default environment variables:
 - `SEND_ALIVE_ON_START=false`
   (set to `true` if you want the service to send and log a `MeshSpy Alive`
   message on start-up)
+- `NODE_DB_PATH=nodes.db`
+  (path for the SQLite database that stores node information; change this to
+  override the default location)
 
 Start the container using the defaults:
 
@@ -89,10 +92,11 @@ periodically show container logs:
 
 Both options can be combined if required.
 
-The service stores information about all discovered nodes in a SQLite database
-named `nodes.db` inside the container data directory. Each time a `NodeInfo`
-protobuf message is received it is converted and inserted or updated in this
-database so that external tools can inspect the mesh topology.
+The service stores information about all discovered nodes in a SQLite database.
+By default this file is `nodes.db` inside the container data directory. Set the
+`NODE_DB_PATH` environment variable to use a different file. Each time a
+`NodeInfo` protobuf message is received it is converted and inserted or updated
+in this database so that external tools can inspect the mesh topology.
 
 ## Web Application
 


### PR DESCRIPTION
## Summary
- note the NODE_DB_PATH env variable in the Running section
- explain that the default path is `nodes.db` and how to override it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68668e4d01988323ba6fde9c3514d59e