### PR TITLE
Improve node resolution and display node list in web UI

### DIFF
--- a/cmd/webapp/index.html
+++ b/cmd/webapp/index.html
@@ -10,6 +10,8 @@
 <body>
 <h1>MeshSpy Messages</h1>
 <div id="messages"></div>
+<h2>Nodes</h2>
+<ul id="nodes"></ul>
 <form id="form">
   <input id="text" autocomplete="off" placeholder="Type a message"/>
   <button type="submit">Send</button>
@@ -39,6 +41,15 @@ document.getElementById("defaultButton").onclick = () => {
   echo.textContent = "You: Hello from web";
   document.getElementById("messages").appendChild(echo);
 };
+
+fetch("/nodes").then(r => r.json()).then(nodes => {
+  const list = document.getElementById("nodes");
+  nodes.forEach(n => {
+    const li = document.createElement("li");
+    li.textContent = n.LongName || n.ID;
+    list.appendChild(li);
+  });
+});
 </script>
 </body>
 </html>

--- a/nodemap/nodemap.go
+++ b/nodemap/nodemap.go
@@ -50,3 +50,15 @@ func (m *Map) Resolve(id string) string {
 	}
 	return id
 }
+
+// ResolveLong returns the long name for the given node id if known, otherwise
+// it falls back to the id itself.
+func (m *Map) ResolveLong(id string) string {
+	m.mu.RLock()
+	e, ok := m.nodes[id]
+	m.mu.RUnlock()
+	if ok && e.Long != "" {
+		return e.Long
+	}
+	return id
+}

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -83,7 +83,7 @@ func ReadLoop(portName string, baud int, debug bool, nm *nodemap.Map, handleNode
 			continue
 		}
 		if nm != nil {
-			node = nm.Resolve(node)
+			node = nm.ResolveLong(node)
 		}
 		if node == lastNode {
 			continue


### PR DESCRIPTION
## Summary
- resolve nodes by long name in serial reader
- expose nodes from NodeStore over `/nodes` in the webapp
- list node names on the web UI page

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68669288d60c8323b265aa1c6d23321a