### PR TITLE
Send welcome message even if node info fails

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -127,7 +127,10 @@ func main() {
 		fmt.Printf("ℹ️  Info dispositivo Meshtastic:\n%s\n", output)
 	}
 
-	if info, err := mqttpkg.GetLocalNodeInfo(cfg.SerialPort); err == nil {
+	info, err := mqttpkg.GetLocalNodeInfo(cfg.SerialPort)
+	if err != nil {
+		log.Printf("⚠️ Lettura info nodo fallita: %v", err)
+	} else {
 		if err := mqttpkg.SaveNodeInfo(info, "nodes.json"); err != nil {
 			log.Printf("⚠️ Salvataggio info nodo fallito: %v", err)
 		}
@@ -140,13 +143,11 @@ func main() {
 		} else {
 			log.Printf("✅ Configurazione salvata in %s", cfgFile)
 		}
-		if err := serial.SendTextMessage(cfg.SerialPort, welcomeMessage); err != nil {
-			log.Printf("⚠️ Errore invio messaggio di benvenuto: %v", err)
-		} else {
-			log.Printf("✅ Messaggio di benvenuto inviato")
-		}
+	}
+	if err := serial.SendTextMessage(cfg.SerialPort, welcomeMessage); err != nil {
+		log.Printf("⚠️ Errore invio messaggio di benvenuto: %v", err)
 	} else {
-		log.Printf("⚠️ Lettura info nodo fallita: %v", err)
+		log.Printf("✅ Messaggio di benvenuto inviato")
 	}
 
 	// Avvia la lettura dalla porta seriale in un goroutine


### PR DESCRIPTION
## Summary
- always send welcome message on startup

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68669869326483239ca12c95747e9d55