### PR TITLE
Add message sending via meshtastic-go

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -173,3 +173,17 @@ func SaveNodeInfo(info *NodeInfo, path string) error {
 	enc.SetIndent("", "  ")
 	return enc.Encode(info)
 }
+
+// SendText sends a text message to an optional destination using meshtastic-go
+func SendText(port, dest, msg string) error {
+	args := []string{"--port", port, "--sendtext", msg}
+	if dest != "" {
+		args = append(args, "--dest", dest)
+	}
+	cmd := exec.Command("/usr/local/bin/meshtastic-go", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("meshtastic-go failed: %v - %s", err, string(output))
+	}
+	return nil
+}

--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -14,11 +15,14 @@ import (
 	"meshspy/client"
 	"meshspy/config"
 	"meshspy/serial"
-	
 )
 
 func main() {
 	log.Println("🔥 MeshSpy avviamento iniziato...")
+
+	msg := flag.String("sendtext", "", "Messaggio da inviare invece di avviare il listener")
+	dest := flag.String("dest", "", "Nodo destinatario (opzionale)")
+	flag.Parse()
 
 	// Carica .env.runtime se presente
 	if err := godotenv.Load(".env.runtime"); err != nil {
@@ -29,6 +33,14 @@ func main() {
 
 	// Carica la configurazione dalle variabili d'ambiente
 	cfg := config.Load()
+
+	if *msg != "" {
+		if err := mqtt.SendText(cfg.SerialPort, *dest, *msg); err != nil {
+			log.Fatalf("❌ Errore invio messaggio: %v", err)
+		}
+		log.Printf("✅ Messaggio inviato a %s", *dest)
+		return
+	}
 
 	// Connessione al broker MQTT
 	client, err := mqtt.ConnectMQTT(cfg)
@@ -60,7 +72,6 @@ func main() {
 	} else {
 		log.Printf("⚠️ Lettura info nodo fallita: %v", err)
 	}
-	
 
 	// Avvia la lettura dalla porta seriale in un goroutine
 	go func() {


### PR DESCRIPTION
## Summary
- allow meshspy CLI to send messages to a specific node
- add SendText helper using meshtastic-go

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686697e7929883239a666a577c1594b4