### PR TITLE
Add protobuf decoders and extend serial handling

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -158,7 +158,7 @@ func main() {
 					log.Printf("⚠️ aggiornamento db nodi: %v", err)
 				}
 			}
-		}, func(data string) {
+		}, nil, nil, func(data string) {
 			// Pubblica ogni messaggio ricevuto sul topic MQTT
 			token := client.Publish(cfg.MQTTTopic, 0, false, data)
 			token.Wait()

--- a/decoder/myinfo.go
+++ b/decoder/myinfo.go
@@ -1,0 +1,34 @@
+package decoder
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	latestpb "meshspy/proto/latest/meshtastic"
+)
+
+// DecodeMyInfo decodes a protobuf blob into a MyNodeInfo message.
+func DecodeMyInfo(data []byte, version string) (*latestpb.MyNodeInfo, error) {
+	if len(data) >= headerLen && data[0] == start1 && data[1] == start2 {
+		l := int(data[2])<<8 | int(data[3])
+		if len(data) >= headerLen+l {
+			data = data[headerLen : headerLen+l]
+		} else {
+			return nil, fmt.Errorf("incomplete frame")
+		}
+	}
+	switch version {
+	case "", "latest":
+		var fr latestpb.FromRadio
+		if err := proto.Unmarshal(data, &fr); err == nil && fr.GetMyInfo() != nil {
+			return fr.GetMyInfo(), nil
+		}
+		var mi latestpb.MyNodeInfo
+		if err := proto.Unmarshal(data, &mi); err == nil && mi.MyNodeNum != 0 {
+			return &mi, nil
+		}
+		return nil, fmt.Errorf("not a MyNodeInfo message")
+	default:
+		return nil, fmt.Errorf("unsupported proto version: %s", version)
+	}
+}

--- a/decoder/myinfo_test.go
+++ b/decoder/myinfo_test.go
@@ -1,0 +1,41 @@
+package decoder
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	pb "meshspy/proto/latest/meshtastic"
+)
+
+func TestDecodeMyInfo(t *testing.T) {
+	orig := &pb.MyNodeInfo{MyNodeNum: 123, RebootCount: 2}
+	data, err := proto.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	mi, err := DecodeMyInfo(data, "latest")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if mi.GetMyNodeNum() != 123 {
+		t.Fatalf("unexpected node num %d", mi.GetMyNodeNum())
+	}
+}
+
+func TestDecodeMyInfoFramed(t *testing.T) {
+	orig := &pb.MyNodeInfo{MyNodeNum: 7, RebootCount: 1}
+	fr := &pb.FromRadio{PayloadVariant: &pb.FromRadio_MyInfo{MyInfo: orig}}
+	payload, err := proto.Marshal(fr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	header := []byte{0x94, 0xC3, byte(len(payload) >> 8), byte(len(payload))}
+	frame := append(header, payload...)
+	mi, err := DecodeMyInfo(frame, "latest")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if mi.GetMyNodeNum() != 7 {
+		t.Fatalf("unexpected result %+v", mi)
+	}
+}

--- a/decoder/telemetry.go
+++ b/decoder/telemetry.go
@@ -1,0 +1,47 @@
+package decoder
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	latestpb "meshspy/proto/latest/meshtastic"
+)
+
+// DecodeTelemetry decodes a protobuf blob into a Telemetry message.
+func DecodeTelemetry(data []byte, version string) (*latestpb.Telemetry, error) {
+	if len(data) >= headerLen && data[0] == start1 && data[1] == start2 {
+		l := int(data[2])<<8 | int(data[3])
+		if len(data) >= headerLen+l {
+			data = data[headerLen : headerLen+l]
+		} else {
+			return nil, fmt.Errorf("incomplete frame")
+		}
+	}
+	switch version {
+	case "", "latest":
+		var fr latestpb.FromRadio
+		if err := proto.Unmarshal(data, &fr); err == nil {
+			if pkt := fr.GetPacket(); pkt != nil {
+				if d := pkt.GetDecoded(); d != nil && d.GetPortnum() == latestpb.PortNum_TELEMETRY_APP {
+					var tel latestpb.Telemetry
+					if err := proto.Unmarshal(d.GetPayload(), &tel); err == nil {
+						return &tel, nil
+					}
+				}
+			}
+		}
+		var tel latestpb.Telemetry
+		if err := proto.Unmarshal(data, &tel); err == nil && tel.Time != 0 {
+			return &tel, nil
+		}
+		var d latestpb.Data
+		if err := proto.Unmarshal(data, &d); err == nil && len(d.GetPayload()) > 0 && d.GetPortnum() == latestpb.PortNum_TELEMETRY_APP {
+			if err := proto.Unmarshal(d.GetPayload(), &tel); err == nil {
+				return &tel, nil
+			}
+		}
+		return nil, fmt.Errorf("not a Telemetry message")
+	default:
+		return nil, fmt.Errorf("unsupported proto version: %s", version)
+	}
+}

--- a/decoder/telemetry_test.go
+++ b/decoder/telemetry_test.go
@@ -1,0 +1,26 @@
+package decoder
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	pb "meshspy/proto/latest/meshtastic"
+)
+
+func TestDecodeTelemetry(t *testing.T) {
+	orig := &pb.Telemetry{
+		Time:    1234,
+		Variant: &pb.Telemetry_DeviceMetrics{DeviceMetrics: &pb.DeviceMetrics{BatteryLevel: proto.Uint32(80)}},
+	}
+	data, err := proto.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	tel, err := DecodeTelemetry(data, "latest")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if tel.GetTime() != 1234 {
+		t.Fatalf("unexpected time %d", tel.GetTime())
+	}
+}


### PR DESCRIPTION
## Summary
- add decoder functions for MyNodeInfo and Telemetry messages
- update serial.ReadLoop to detect MyInfo and Telemetry messages
- adjust main program for new ReadLoop signature
- add unit tests for MyInfo and Telemetry decoding

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68669864f4588323b959fc8fcc15d9ec