### PR TITLE
Handle Telemetry and Text messages

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -158,7 +158,7 @@ func main() {
 					log.Printf("⚠️ aggiornamento db nodi: %v", err)
 				}
 			}
-		}, func(data string) {
+		}, nil, nil, func(data string) {
 			// Pubblica ogni messaggio ricevuto sul topic MQTT
 			token := client.Publish(cfg.MQTTTopic, 0, false, data)
 			token.Wait()

--- a/decoder/messages.go
+++ b/decoder/messages.go
@@ -1,0 +1,82 @@
+package decoder
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	latestpb "meshspy/proto/latest/meshtastic"
+)
+
+// stripFrame removes the radio framing bytes if present.
+func stripFrame(data []byte) ([]byte, error) {
+	if len(data) >= headerLen && data[0] == start1 && data[1] == start2 {
+		l := int(data[2])<<8 | int(data[3])
+		if len(data) >= headerLen+l {
+			return data[headerLen : headerLen+l], nil
+		}
+		return nil, fmt.Errorf("incomplete frame")
+	}
+	return data, nil
+}
+
+// DecodeTelemetry decodes a protobuf Telemetry message from the given data.
+// It supports the same framing as DecodeNodeInfo.
+func DecodeTelemetry(data []byte, version string) (*latestpb.Telemetry, error) {
+	var err error
+	data, err = stripFrame(data)
+	if err != nil {
+		return nil, err
+	}
+	switch version {
+	case "", "latest":
+		var fr latestpb.FromRadio
+		if err := proto.Unmarshal(data, &fr); err == nil {
+			if pkt := fr.GetPacket(); pkt != nil {
+				if dec := pkt.GetDecoded(); dec != nil {
+					if dec.GetPortnum() == latestpb.PortNum_TELEMETRY_APP {
+						var tm latestpb.Telemetry
+						if err := proto.Unmarshal(dec.GetPayload(), &tm); err == nil {
+							return &tm, nil
+						}
+					}
+				}
+			}
+		}
+		var tm latestpb.Telemetry
+		if err := proto.Unmarshal(data, &tm); err == nil && tm.GetVariant() != nil {
+			return &tm, nil
+		}
+		return nil, fmt.Errorf("not a Telemetry message")
+	default:
+		return nil, fmt.Errorf("unsupported proto version: %s", version)
+	}
+}
+
+// DecodeText extracts a plain text message from the given data.
+func DecodeText(data []byte, version string) (string, error) {
+	var err error
+	data, err = stripFrame(data)
+	if err != nil {
+		return "", err
+	}
+	switch version {
+	case "", "latest":
+		var fr latestpb.FromRadio
+		if err := proto.Unmarshal(data, &fr); err == nil {
+			if pkt := fr.GetPacket(); pkt != nil {
+				if dec := pkt.GetDecoded(); dec != nil {
+					if dec.GetPortnum() == latestpb.PortNum_TEXT_MESSAGE_APP {
+						return string(dec.GetPayload()), nil
+					}
+				}
+			}
+		}
+		var d latestpb.Data
+		if err := proto.Unmarshal(data, &d); err == nil && d.GetPortnum() == latestpb.PortNum_TEXT_MESSAGE_APP {
+			return string(d.GetPayload()), nil
+		}
+		return "", fmt.Errorf("not a text message")
+	default:
+		return "", fmt.Errorf("unsupported proto version: %s", version)
+	}
+}

--- a/decoder/messages_test.go
+++ b/decoder/messages_test.go
@@ -1,0 +1,56 @@
+package decoder
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	pb "meshspy/proto/latest/meshtastic"
+)
+
+func TestDecodeText(t *testing.T) {
+	d := &pb.Data{
+		Portnum: pb.PortNum_TEXT_MESSAGE_APP,
+		Payload: []byte("hello"),
+	}
+	mp := &pb.MeshPacket{PayloadVariant: &pb.MeshPacket_Decoded{Decoded: d}}
+	fr := &pb.FromRadio{PayloadVariant: &pb.FromRadio_Packet{Packet: mp}}
+	data, err := proto.Marshal(fr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	txt, err := DecodeText(data, "latest")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if txt != "hello" {
+		t.Fatalf("unexpected text %q", txt)
+	}
+}
+
+func TestDecodeTelemetry(t *testing.T) {
+	tm := &pb.Telemetry{
+		Time:    12345,
+		Variant: &pb.Telemetry_DeviceMetrics{DeviceMetrics: &pb.DeviceMetrics{}},
+	}
+	payload, err := proto.Marshal(tm)
+	if err != nil {
+		t.Fatalf("marshal telemetry: %v", err)
+	}
+	d := &pb.Data{
+		Portnum: pb.PortNum_TELEMETRY_APP,
+		Payload: payload,
+	}
+	mp := &pb.MeshPacket{PayloadVariant: &pb.MeshPacket_Decoded{Decoded: d}}
+	fr := &pb.FromRadio{PayloadVariant: &pb.FromRadio_Packet{Packet: mp}}
+	data, err := proto.Marshal(fr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dec, err := DecodeTelemetry(data, "latest")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if dec.GetTime() != tm.GetTime() {
+		t.Fatalf("unexpected time %d", dec.GetTime())
+	}
+}


### PR DESCRIPTION
## Summary
- add decoder for telemetry and plain text messages
- call new handlers in serial.ReadLoop
- adapt main to new ReadLoop signature
- test telemetry and text decoders

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6866986912d883238bc553b5c6ea505e