### PR TITLE
Add serial port manager

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -65,24 +65,30 @@ func main() {
 	}
 
 	// Sottoscrivi al topic dei comandi e inoltra i messaggi sulla seriale
+	var portMgr *serial.Manager
+
 	token := client.Subscribe(cfg.CommandTopic, 0, func(c paho.Client, m paho.Message) {
 		msg := string(m.Payload())
+		if portMgr == nil {
+			log.Printf("❌ Porta seriale non inizializzata")
+			return
+		}
 		switch {
 		case msg == "sendhello":
-			if err := serial.SendTextMessage(cfg.SerialPort, welcomeMessage); err != nil {
+			if err := portMgr.SendTextMessage(welcomeMessage); err != nil {
 				log.Printf("❌ Errore invio messaggio standard: %v", err)
 			} else {
 				log.Printf("✅ Messaggio standard inviato")
 			}
 		case strings.HasPrefix(msg, "send:"):
 			text := strings.TrimPrefix(msg, "send:")
-			if err := serial.SendTextMessage(cfg.SerialPort, text); err != nil {
+			if err := portMgr.SendTextMessage(text); err != nil {
 				log.Printf("❌ Errore invio messaggio personalizzato: %v", err)
 			} else {
 				log.Printf("✅ Messaggio personalizzato inviato: %s", text)
 			}
 		default:
-			if err := serial.Send(cfg.SerialPort, cfg.BaudRate, msg); err != nil {
+			if err := portMgr.Send(msg); err != nil {
 				log.Printf("❌ Errore invio seriale: %v", err)
 			} else {
 				log.Printf("➡️  Comando inoltrato alla seriale: %s", m.Payload())
@@ -159,9 +165,15 @@ func main() {
 		log.Printf("✅ Messaggio di benvenuto inviato")
 	}
 
+	portMgr, err = serial.OpenManager(cfg.SerialPort, cfg.BaudRate)
+	if err != nil {
+		log.Fatalf("❌ apertura porta seriale: %v", err)
+	}
+	defer portMgr.Close()
+
 	// Avvia la lettura dalla porta seriale in un goroutine
 	go func() {
-		serial.ReadLoop(cfg.SerialPort, cfg.BaudRate, cfg.Debug, nodes, func(ni *latestpb.NodeInfo) {
+		portMgr.ReadLoop(cfg.Debug, nodes, func(ni *latestpb.NodeInfo) {
 			info := mqttpkg.NodeInfoFromProto(ni)
 			if info != nil {
 				if err := nodeStore.Upsert(info); err != nil {

--- a/serial/manager.go
+++ b/serial/manager.go
@@ -1,0 +1,106 @@
+package serial
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	seriallib "go.bug.st/serial"
+	"google.golang.org/protobuf/proto"
+
+	"meshspy/nodemap"
+	latestpb "meshspy/proto/latest/meshtastic"
+)
+
+// Manager provides exclusive access to a serial port. It opens the
+// port once and allows sending commands and starting a read loop
+// without reopening the device.
+type Manager struct {
+	name string
+	baud int
+	port seriallib.Port
+	mu   sync.Mutex
+}
+
+// OpenManager opens the given serial port at the specified baud rate
+// and returns a Manager that can be used for reading and writing.
+func OpenManager(portName string, baud int) (*Manager, error) {
+	p, err := seriallib.Open(portName, &seriallib.Mode{BaudRate: baud})
+	if err != nil {
+		return nil, err
+	}
+	p.SetReadTimeout(5 * time.Second)
+	return &Manager{name: portName, baud: baud, port: p}, nil
+}
+
+// Close closes the underlying serial port.
+func (m *Manager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.port == nil {
+		return nil
+	}
+	err := m.port.Close()
+	m.port = nil
+	return err
+}
+
+// Send writes the given string to the serial port using the existing handle.
+func (m *Manager) Send(data string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.port == nil {
+		return fmt.Errorf("serial port not open")
+	}
+	log.Printf("\u2191 write to %s: %q", m.name, data)
+	_, err := m.port.Write([]byte(data))
+	return err
+}
+
+// SendTextMessage sends a broadcast text message over the mesh network
+// using the open serial port.
+func (m *Manager) SendTextMessage(text string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.port == nil {
+		return fmt.Errorf("serial port not open")
+	}
+	pkt := &latestpb.MeshPacket{
+		To: 0xffffffff,
+		PayloadVariant: &latestpb.MeshPacket_Decoded{
+			Decoded: &latestpb.Data{
+				Portnum: latestpb.PortNum_TEXT_MESSAGE_APP,
+				Payload: []byte(text),
+			},
+		},
+	}
+	tr := &latestpb.ToRadio{
+		PayloadVariant: &latestpb.ToRadio_Packet{Packet: pkt},
+	}
+	payload, err := proto.Marshal(tr)
+	if err != nil {
+		return err
+	}
+	frame := make([]byte, 4+len(payload))
+	frame[0] = 0x94
+	frame[1] = 0xC3
+	frame[2] = byte(len(payload) >> 8)
+	frame[3] = byte(len(payload))
+	copy(frame[4:], payload)
+	log.Printf("\u2191 write text to %s: %q", m.name, text)
+	_, err = m.port.Write(frame)
+	return err
+}
+
+// ReadLoop starts reading from the serial port using the same logic as the
+// standalone ReadLoop function, but without reopening the port.
+func (m *Manager) ReadLoop(debug bool, nm *nodemap.Map,
+	handleNodeInfo func(*latestpb.NodeInfo),
+	handleTelemetry func(*latestpb.Telemetry),
+	handleText func(string),
+	publish func(string)) {
+
+	readLoop(m.port, m.name, m.baud, debug, nm,
+		handleNodeInfo, handleTelemetry, handleText, publish)
+}

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -46,6 +46,15 @@ func ReadLoop(portName string, baud int, debug bool, nm *nodemap.Map,
 	}
 	defer port.Close()
 
+	readLoop(port, portName, baud, debug, nm,
+		handleNodeInfo, handleTelemetry, handleText, publish)
+}
+
+func readLoop(port serial.Port, portName string, baud int, debug bool, nm *nodemap.Map,
+	handleNodeInfo func(*latestpb.NodeInfo),
+	handleTelemetry func(*latestpb.Telemetry),
+	handleText func(string),
+	publish func(string)) {
 	log.Printf("Listening on serial %s at %d baud", portName, baud)
 
 	const (


### PR DESCRIPTION
## Summary
- add `Manager` struct to manage a single serial port handle
- refactor `ReadLoop` so it can reuse an already opened port
- update main program to use `Manager` for sending commands and messages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686720146db8832380bea07cf5472ed7