### PR TITLE
Fix duplicate telemetry decoding

### DIFF
--- a/serial/serial.go
+++ b/serial/serial.go
@@ -102,13 +102,6 @@ func readLoop(port serial.Port, portName string, baud int, debug bool, protoVers
 			return
 		}
 
-		if tele, err := decoder.DecodeTelemetry([]byte(line), protoVersion); err == nil {
-			if handleTelemetry != nil {
-				handleTelemetry(tele)
-			}
-			return
-		}
-
 		node := parseNodeName(line)
 		if node == "" || node == "0x0" {
 			if debug {


### PR DESCRIPTION
## Summary
- remove second invocation of telemetry decode in `serial.go`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686aecadae088323b5edba6d548bff63