### PR TITLE
Handle firmware ranges for proto

### DIFF
--- a/client/dump_parser_test.go
+++ b/client/dump_parser_test.go
@@ -35,6 +35,12 @@ func TestProtoVersionForFirmware(t *testing.T) {
 	if v := ProtoVersionForFirmware("2.7.0.705515a"); v != "latest" {
 		t.Fatalf("unexpected version %s", v)
 	}
+	if v := ProtoVersionForFirmware("2.1.0"); v != "2.1" {
+		t.Fatalf("unexpected version for 2.1.x: %s", v)
+	}
+	if v := ProtoVersionForFirmware("2.1.5"); v != "2.1" {
+		t.Fatalf("unexpected version for 2.1.x: %s", v)
+	}
 	if v := ProtoVersionForFirmware(""); v != "latest" {
 		t.Fatalf("unexpected empty version %s", v)
 	}

--- a/client/version_map.go
+++ b/client/version_map.go
@@ -10,9 +10,15 @@ func ProtoVersionForFirmware(fw string) string {
 	if fw == "" {
 		return "latest"
 	}
-	// example: 2.1.x might require old proto, here we just default
-	if strings.HasPrefix(fw, "2.") {
-		return "latest"
+
+	parts := strings.SplitN(fw, ".", 3)
+	if len(parts) >= 2 {
+		major, minor := parts[0], parts[1]
+		// Firmware 2.1.x uses the older protobuf schema
+		if major == "2" && minor == "1" {
+			return "2.1"
+		}
 	}
+
 	return "latest"
 }


### PR DESCRIPTION
## Summary
- map firmware 2.1.x to proto version `2.1`
- extend unit tests for proto version mapping

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686aecb7ae7083239c552f77b91a156c