### PR TITLE
Fix web GUI message forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ in this database so that external tools can inspect the mesh topology.
 ## Web Application
 
 A simple web interface lives in `cmd/webapp`. It serves an HTML page and
-forwards MQTT messages over WebSockets. Run it with Go:
+forwards MQTT messages over WebSockets. Messages typed in the page are
+published over MQTT and delivered to the mesh as text packets. Run it with Go:
 
 ```bash
 go run ./cmd/webapp

--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -93,10 +93,10 @@ func main() {
 				log.Printf("✅ Messaggio personalizzato inviato: %s", text)
 			}
 		default:
-			if err := portMgr.Send(msg); err != nil {
-				log.Printf("❌ Errore invio seriale: %v", err)
+			if err := portMgr.SendTextMessage(msg); err != nil {
+				log.Printf("❌ Errore invio messaggio: %v", err)
 			} else {
-				log.Printf("➡️  Comando inoltrato alla seriale: %s", m.Payload())
+				log.Printf("✅ Messaggio inviato: %s", msg)
 			}
 		}
 	})


### PR DESCRIPTION
## Summary
- send MQTT commands from webapp as text messages to the mesh
- document webapp message behaviour

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b949d5fb483239d36b18ab4ee99d8