### PR TITLE
Add single-platform build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Then build the image:
 ./build.sh
 ```
 
+To build the container only for a specific platform set the `BUILD_PLATFORMS`
+environment variable:
+
+```bash
+BUILD_PLATFORMS=linux/amd64 ./build.sh
+```
+
+When unset the script builds images for multiple architectures.
+
 ### Building binaries
 
 To produce standalone binaries for Linux, Windows and macOS, run:

--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,9 @@ TAG="${TAG:-latest}"
 ARCH_ARMV6="linux/arm/v6"
 PLATFORMS_PARALLEL="linux/arm/v7,linux/amd64,linux/386,linux/arm64"
 
+# Permette di specificare piattaforme custom con BUILD_PLATFORMS
+BUILD_PLATFORMS="${BUILD_PLATFORMS:-}"
+
 PROTO_REPO="https://github.com/meshtastic/protobufs.git"
 TMP_DIR=".proto_tmp"
 PROTO_MAP_FILE=".proto_compile_map.sh"
@@ -102,6 +105,23 @@ if ! docker buildx inspect meshspy-builder &>/dev/null; then
 fi
 docker buildx use meshspy-builder
 docker buildx inspect --bootstrap
+
+# Se BUILD_PLATFORMS è impostato, buildiamo solo per quelle
+if [[ -n "$BUILD_PLATFORMS" ]]; then
+  echo "🚀 Build personalizzato per: ${BUILD_PLATFORMS}"
+  BASE="golang:1.21-alpine"
+  if [[ "$BUILD_PLATFORMS" == "$ARCH_ARMV6" ]]; then
+    BASE="arm32v6/golang:1.21.0-alpine"
+  fi
+  docker buildx build \
+    --platform "${BUILD_PLATFORMS}" \
+    --push \
+    -t "${IMAGE}:${TAG}" \
+    --build-arg BASE_IMAGE="$BASE" \
+    .
+  echo "✅ Done! Image ready: ${IMAGE}:${TAG}"
+  exit 0
+fi
 
 # 🔨 Build ARMv6 separata (buildx fallback per piattaforme legacy)
 echo "🐹 Build ARMv6 senza buildx (solo se host ARM compatibile)"


### PR DESCRIPTION
## Summary
- enable BUILD_PLATFORMS variable in `build.sh` to choose target platforms
- document BUILD_PLATFORMS usage in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b967092848323aa73e78c24d67139