### PR TITLE
Fix nodemap name update logic

### DIFF
--- a/nodemap/nodemap.go
+++ b/nodemap/nodemap.go
@@ -24,7 +24,14 @@ func New() *Map {
 func (m *Map) Update(num uint32, long, short string) {
 	id := fmt.Sprintf("0x%x", num)
 	m.mu.Lock()
-	m.nodes[id] = Entry{Long: long, Short: short}
+	e := m.nodes[id]
+	if long != "" {
+		e.Long = long
+	}
+	if short != "" {
+		e.Short = short
+	}
+	m.nodes[id] = e
 	m.mu.Unlock()
 }
 


### PR DESCRIPTION
## Summary
- preserve existing long and short names when updates don't provide them

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b96cc44988323bdba6bfed0f57c5a