### PR TITLE
Add management server integration

### DIFF
--- a/cmd/unifiserver/main.go
+++ b/cmd/unifiserver/main.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+
+	mqttpkg "meshspy/client"
+	"meshspy/config"
+	"meshspy/storage"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/joho/godotenv"
+)
+
+// apiServer holds dependencies for the HTTP API.
+type apiServer struct {
+	mqtt  mqtt.Client
+	cfg   config.Config
+	store *storage.NodeStore
+}
+
+func newServer(m mqtt.Client, cfg config.Config, store *storage.NodeStore) *apiServer {
+	return &apiServer{mqtt: m, cfg: cfg, store: store}
+}
+
+// listNodes returns the known nodes as JSON.
+func (s *apiServer) listNodes(w http.ResponseWriter, r *http.Request) {
+	nodes, err := s.store.List()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(nodes)
+}
+
+// upsertNode stores a NodeInfo received in the request body.
+func (s *apiServer) upsertNode(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var info mqttpkg.NodeInfo
+	if err := json.NewDecoder(r.Body).Decode(&info); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.Upsert(&info); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// sendCommand publishes a command payload on the MQTT command topic.
+func (s *apiServer) sendCommand(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Cmd string `json:"cmd"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	token := s.mqtt.Publish(s.cfg.CommandTopic, 0, false, req.Cmd)
+	token.Wait()
+	if token.Error() != nil {
+		http.Error(w, token.Error().Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func main() {
+	if err := godotenv.Load(".env.runtime"); err != nil {
+		log.Printf("⚠️  .env.runtime not loaded: %v", err)
+	}
+
+	cfg := config.Load()
+	client, err := mqttpkg.ConnectMQTT(cfg)
+	if err != nil {
+		log.Fatalf("MQTT connect error: %v", err)
+	}
+	defer client.Disconnect(250)
+
+	dbPath := os.Getenv("NODE_DB_PATH")
+	if dbPath == "" {
+		dbPath = "nodes.db"
+	}
+	store, err := storage.NewNodeStore(dbPath)
+	if err != nil {
+		log.Fatalf("node store open error: %v", err)
+	}
+	defer store.Close()
+
+	srv := newServer(client, cfg, store)
+	http.HandleFunc("/api/nodes", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			srv.upsertNode(w, r)
+			return
+		}
+		srv.listNodes(w, r)
+	})
+	http.HandleFunc("/api/send", srv.sendCommand)
+
+	port := os.Getenv("SERVER_PORT")
+	if port == "" {
+		port = "8081"
+	}
+	log.Printf("🌐 Management server listening on :%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Debug        bool
 	SendAlive    bool
 	EnableGUI    bool
+	MgmtURL      string
 }
 
 // Load reads configuration values from the environment and returns a Config.
@@ -63,6 +64,7 @@ func Load() Config {
 		Debug:        debug,
 		SendAlive:    sendAlive,
 		EnableGUI:    enableGUI,
+		MgmtURL:      os.Getenv("MGMT_SERVER_URL"),
 	}
 }
 

--- a/mgmtapi/client.go
+++ b/mgmtapi/client.go
@@ -1,0 +1,103 @@
+package mgmtapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	mqttpkg "meshspy/client"
+)
+
+// Client communicates with the management server HTTP API.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// New returns a new API client for the given base URL. If url is empty,
+// the returned client will be nil.
+func New(url string) *Client {
+	if url == "" {
+		return nil
+	}
+	return &Client{
+		baseURL: strings.TrimRight(url, "/"),
+		http:    &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// SendNode uploads a NodeInfo to the management server.
+func (c *Client) SendNode(info *mqttpkg.NodeInfo) error {
+	if c == nil {
+		return nil
+	}
+	b, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/nodes", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("server returned %s", resp.Status)
+	}
+	return nil
+}
+
+// SendCommand sends a command string to the server which will publish it on MQTT.
+func (c *Client) SendCommand(cmd string) error {
+	if c == nil {
+		return nil
+	}
+	payload := struct {
+		Cmd string `json:"cmd"`
+	}{Cmd: cmd}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/send", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("server returned %s", resp.Status)
+	}
+	return nil
+}
+
+// ListNodes retrieves the known nodes from the server.
+func (c *Client) ListNodes() ([]*mqttpkg.NodeInfo, error) {
+	if c == nil {
+		return nil, nil
+	}
+	resp, err := c.http.Get(c.baseURL + "/api/nodes")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("server returned %s", resp.Status)
+	}
+	var nodes []*mqttpkg.NodeInfo
+	if err := json.NewDecoder(resp.Body).Decode(&nodes); err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}


### PR DESCRIPTION
## Summary
- extend `unifiserver` with POST `/api/nodes` to store node data
- create `mgmtapi` client for HTTP management API
- configure MeshSpy with `MGMT_SERVER_URL`
- send node info to management server from MeshSpy

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b942872048323ba716e114522a500