### PR TITLE
Handle empty NodeInfo messages

### DIFF
--- a/nodemap/nodemap.go
+++ b/nodemap/nodemap.go
@@ -39,6 +39,9 @@ func (m *Map) UpdateFromProto(ni *latestpb.NodeInfo) {
 	if ni == nil || ni.User == nil {
 		return
 	}
+	if ni.GetNum() == 0 && ni.User.GetLongName() == "" && ni.User.GetShortName() == "" {
+		return
+	}
 	m.Update(ni.GetNum(), ni.User.GetLongName(), ni.User.GetShortName())
 }
 

--- a/nodemap/nodemap_test.go
+++ b/nodemap/nodemap_test.go
@@ -15,3 +15,10 @@ func ExampleMap_UpdateFromProto() {
 	fmt.Println(nm.Resolve("0x1234"))
 	// Output: Alice
 }
+
+func ExampleMap_UpdateFromProto_ignoreEmpty() {
+	nm := New()
+	nm.UpdateFromProto(&latestpb.NodeInfo{Num: 0x0, User: &latestpb.User{}})
+	fmt.Println(nm.Resolve("0x0"))
+	// Output: 0x0
+}


### PR DESCRIPTION
## Summary
- avoid storing empty node info in nodemap
- test that empty NodeInfo values are ignored

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ba0c5cd4883239c5bc624be2d84c1