### PR TITLE
fix: handle scanner errors when parsing node list

### DIFF
--- a/client/nodes.go
+++ b/client/nodes.go
@@ -16,11 +16,11 @@ func GetMeshNodes(port string) ([]*NodeInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ParseNodesOutput(output), nil
+	return ParseNodesOutput(output)
 }
 
 // ParseNodesOutput parses a table of nodes produced by meshtastic-go.
-func ParseNodesOutput(data []byte) []*NodeInfo {
+func ParseNodesOutput(data []byte) ([]*NodeInfo, error) {
 	var nodes []*NodeInfo
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
@@ -56,5 +56,8 @@ func ParseNodesOutput(data []byte) []*NodeInfo {
 			Longitude: float64(lon) / 1e7,
 		})
 	}
-	return nodes
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return nodes, nil
 }

--- a/client/nodes_test.go
+++ b/client/nodes_test.go
@@ -5,7 +5,10 @@ import "testing"
 func TestParseNodesOutput(t *testing.T) {
 	sample := "| 1773582993     | HB9ODI-Scereda 900m| N/A            | " +
 		"950            | 458915999      | 89875399       |\n"
-	nodes := ParseNodesOutput([]byte(sample))
+	nodes, err := ParseNodesOutput([]byte(sample))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(nodes) != 1 {
 		t.Fatalf("expected 1 node, got %d", len(nodes))
 	}


### PR DESCRIPTION
## Summary
- propagate scanner errors in `ParseNodesOutput`
- update `GetMeshNodes` and unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686bb7d4f69c8323b9ecf43c269f6e81