### PR TITLE
Implement node info caching

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -26,5 +27,74 @@ func TestGetLocalNodeInfoScanError(t *testing.T) {
 	}
 	if errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("script did not run correctly: %v", err)
+	}
+}
+
+func TestLoadNodeInfo(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "info.json")
+	want := &NodeInfo{LongName: "Foo", FirmwareVersion: "1.0"}
+	if err := SaveNodeInfo(want, path); err != nil {
+		t.Fatalf("SaveNodeInfo failed: %v", err)
+	}
+	got, err := LoadNodeInfo(path)
+	if err != nil {
+		t.Fatalf("LoadNodeInfo returned error: %v", err)
+	}
+	if got.LongName != want.LongName || got.FirmwareVersion != want.FirmwareVersion {
+		t.Fatalf("mismatch: got %+v want %+v", got, want)
+	}
+}
+
+func TestGetLocalNodeInfoCachedUsesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "info.json")
+	want := &NodeInfo{LongName: "Bar", FirmwareVersion: "2.0"}
+	if err := SaveNodeInfo(want, path); err != nil {
+		t.Fatalf("SaveNodeInfo failed: %v", err)
+	}
+
+	scriptPath := "/usr/local/bin/meshtastic-go"
+	marker := filepath.Join(dir, "executed")
+	script := "#!/bin/sh\ntouch " + marker + "\nexit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to create stub script: %v", err)
+	}
+	defer os.Remove(scriptPath)
+
+	got, err := GetLocalNodeInfoCached("dummy", path)
+	if err != nil {
+		t.Fatalf("GetLocalNodeInfoCached returned error: %v", err)
+	}
+	if got.LongName != want.LongName || got.FirmwareVersion != want.FirmwareVersion {
+		t.Fatalf("unexpected info: got %+v want %+v", got, want)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatalf("meshtastic-go was executed")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stat marker: %v", err)
+	}
+}
+
+func TestGetLocalNodeInfoCachedFetches(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "info.json")
+
+	scriptPath := "/usr/local/bin/meshtastic-go"
+	script := "#!/bin/sh\necho 'Node Info'\necho 'User id:\"id1\" long_name:\"Baz\" short_name:\"B\" macaddr:\"12\" hw_model:TBEAM role:CLIENT'\necho 'FirmwareVersion 3.0'\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to create stub script: %v", err)
+	}
+	defer os.Remove(scriptPath)
+
+	info, err := GetLocalNodeInfoCached("dummy", path)
+	if err != nil {
+		t.Fatalf("GetLocalNodeInfoCached returned error: %v", err)
+	}
+	if info.LongName != "Baz" || info.FirmwareVersion != "3.0" {
+		t.Fatalf("unexpected info: %+v", info)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("info not saved: %v", err)
 	}
 }

--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -146,7 +146,7 @@ func main() {
 	}
 
 	var protoVer string
-	info, err := mqttpkg.GetLocalNodeInfo(cfg.SerialPort)
+	info, err := mqttpkg.GetLocalNodeInfoCached(cfg.SerialPort, "nodes.json")
 	if err != nil {
 		log.Printf("⚠️ Lettura info nodo fallita: %v", err)
 	} else {


### PR DESCRIPTION
## Summary
- add `LoadNodeInfo` and `GetLocalNodeInfoCached` helpers
- use caching when getting local node info
- test new node info cache logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686bb85d650c8323aaeb7d1787df5f4d