### PR TITLE
Add MyInfo handling and storage

### DIFF
--- a/client/proto_convert.go
+++ b/client/proto_convert.go
@@ -45,3 +45,14 @@ func NodeInfoFromProto(ni *latestpb.NodeInfo) *NodeInfo {
 	info.IsKeyManuallyVerified = ni.GetIsKeyManuallyVerified()
 	return info
 }
+
+// NodeInfoFromMyInfo converts a MyNodeInfo message to the internal NodeInfo type.
+func NodeInfoFromMyInfo(mi *latestpb.MyNodeInfo) *NodeInfo {
+	if mi == nil {
+		return nil
+	}
+	return &NodeInfo{
+		ID:  fmt.Sprintf("0x%x", mi.GetMyNodeNum()),
+		Num: mi.GetMyNodeNum(),
+	}
+}

--- a/client/proto_convert_test.go
+++ b/client/proto_convert_test.go
@@ -84,3 +84,14 @@ func protoFloat32(v float32) *float32 { return &v }
 func protoInt32(v int32) *int32       { return &v }
 
 func protoUint32(v uint32) *uint32 { return &v }
+
+func TestNodeInfoFromMyInfo(t *testing.T) {
+	mi := &pb.MyNodeInfo{MyNodeNum: 123}
+	info := NodeInfoFromMyInfo(mi)
+	if info == nil {
+		t.Fatal("nil info")
+	}
+	if info.ID != "0x7b" || info.Num != 123 {
+		t.Fatalf("unexpected result: %+v", info)
+	}
+}

--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -205,6 +205,16 @@ func main() {
 					log.Printf("⚠️ invio info nodo al server: %v", err)
 				}
 			}
+		}, func(mi *latestpb.MyNodeInfo) {
+			info := mqttpkg.NodeInfoFromMyInfo(mi)
+			if info != nil {
+				if err := nodeStore.Upsert(info); err != nil {
+					log.Printf("⚠️ aggiornamento db nodi: %v", err)
+				}
+				if err := mgmt.SendNode(info); err != nil {
+					log.Printf("⚠️ invio info nodo al server: %v", err)
+				}
+			}
 		}, nil, nil, func(data string) {
 			// Pubblica ogni messaggio ricevuto sul topic MQTT
 			token := client.Publish(cfg.MQTTTopic, 0, false, data)

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -92,6 +92,14 @@ func Run(cfg config.Config, nodeStore *storage.NodeStore) {
 					}
 				}
 			},
+			func(mi *latestpb.MyNodeInfo) {
+				info := mqttpkg.NodeInfoFromMyInfo(mi)
+				if info != nil {
+					if err := nodeStore.Upsert(info); err == nil {
+						a.QueueUpdate(updateNodes)
+					}
+				}
+			},
 			nil,
 			func(txt string) {
 				a.QueueUpdate(func() {

--- a/serial/manager.go
+++ b/serial/manager.go
@@ -97,10 +97,11 @@ func (m *Manager) SendTextMessage(text string) error {
 // standalone ReadLoop function, but without reopening the port.
 func (m *Manager) ReadLoop(debug bool, protoVersion string, nm *nodemap.Map,
 	handleNodeInfo func(*latestpb.NodeInfo),
+	handleMyInfo func(*latestpb.MyNodeInfo),
 	handleTelemetry func(*latestpb.Telemetry),
 	handleText func(string),
 	publish func(string)) {
 
 	readLoop(m.port, m.name, m.baud, debug, protoVersion, nm,
-		handleNodeInfo, handleTelemetry, handleText, publish)
+		handleNodeInfo, handleMyInfo, handleTelemetry, handleText, publish)
 }


### PR DESCRIPTION
## Summary
- decode `MyNodeInfo` protobuf messages in serial read loops
- convert `MyNodeInfo` to `NodeInfo`
- store results via callbacks in meshspy and GUI

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686bc31be0cc832394d79c3e5fdc2ec0