### PR TITLE
Add v2.1 message decoding

### DIFF
--- a/decoder/messages_test.go
+++ b/decoder/messages_test.go
@@ -27,6 +27,28 @@ func TestDecodeText(t *testing.T) {
 	}
 }
 
+func TestDecodeTextFramedV21(t *testing.T) {
+	d := &pb.Data{
+		Portnum: pb.PortNum_TEXT_MESSAGE_APP,
+		Payload: []byte("hi"),
+	}
+	mp := &pb.MeshPacket{PayloadVariant: &pb.MeshPacket_Decoded{Decoded: d}}
+	fr := &pb.FromRadio{PayloadVariant: &pb.FromRadio_Packet{Packet: mp}}
+	payload, err := proto.Marshal(fr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	header := []byte{0x44, 0x03, byte(len(payload) >> 8), byte(len(payload))}
+	frame := append(header, payload...)
+	txt, err := DecodeText(frame, "2.1")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if txt != "hi" {
+		t.Fatalf("unexpected text %q", txt)
+	}
+}
+
 func TestDecodeTelemetry(t *testing.T) {
 	tm := &pb.Telemetry{
 		Time:    12345,
@@ -47,6 +69,33 @@ func TestDecodeTelemetry(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 	dec, err := DecodeTelemetry(data, "latest")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if dec.GetTime() != tm.GetTime() {
+		t.Fatalf("unexpected time %d", dec.GetTime())
+	}
+}
+
+func TestDecodeTelemetryFramedV21(t *testing.T) {
+	tm := &pb.Telemetry{
+		Time:    777,
+		Variant: &pb.Telemetry_DeviceMetrics{DeviceMetrics: &pb.DeviceMetrics{}},
+	}
+	payload, err := proto.Marshal(tm)
+	if err != nil {
+		t.Fatalf("marshal telemetry: %v", err)
+	}
+	d := &pb.Data{Portnum: pb.PortNum_TELEMETRY_APP, Payload: payload}
+	mp := &pb.MeshPacket{PayloadVariant: &pb.MeshPacket_Decoded{Decoded: d}}
+	fr := &pb.FromRadio{PayloadVariant: &pb.FromRadio_Packet{Packet: mp}}
+	data, err := proto.Marshal(fr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	header := []byte{0x44, 0x03, byte(len(data) >> 8), byte(len(data))}
+	frame := append(header, data...)
+	dec, err := DecodeTelemetry(frame, "2.1")
 	if err != nil {
 		t.Fatalf("decode failed: %v", err)
 	}

--- a/decoder/nodeinfo.go
+++ b/decoder/nodeinfo.go
@@ -10,22 +10,21 @@ import (
 const (
 	start1    = 0x94
 	start2    = 0xC3
+	start1v21 = 0x44
+	start2v21 = 0x03
 	headerLen = 4
 )
 
 // DecodeNodeInfo decodes a protobuf blob into a NodeInfo message.
 // Currently only the "latest" proto version is supported.
 func DecodeNodeInfo(data []byte, version string) (*latestpb.NodeInfo, error) {
-	if len(data) >= headerLen && data[0] == start1 && data[1] == start2 {
-		l := int(data[2])<<8 | int(data[3])
-		if len(data) >= headerLen+l {
-			data = data[headerLen : headerLen+l]
-		} else {
-			return nil, fmt.Errorf("incomplete frame")
-		}
+	var err error
+	data, err = stripFrame(data)
+	if err != nil {
+		return nil, err
 	}
 	switch version {
-	case "", "latest":
+	case "", "latest", "2.1":
 		var fr latestpb.FromRadio
 		if err := proto.Unmarshal(data, &fr); err == nil && fr.GetNodeInfo() != nil {
 			return fr.GetNodeInfo(), nil

--- a/decoder/nodeinfo_test.go
+++ b/decoder/nodeinfo_test.go
@@ -45,3 +45,24 @@ func TestDecodeNodeInfoFramed(t *testing.T) {
 		t.Fatalf("unexpected result %+v", ni)
 	}
 }
+
+func TestDecodeNodeInfoFramedV21(t *testing.T) {
+	orig := &pb.NodeInfo{
+		Num:  55,
+		User: &pb.User{Id: "v21", LongName: "Charlie", ShortName: "C"},
+	}
+	fr := &pb.FromRadio{PayloadVariant: &pb.FromRadio_NodeInfo{NodeInfo: orig}}
+	payload, err := proto.Marshal(fr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	header := []byte{0x44, 0x03, byte(len(payload) >> 8), byte(len(payload))}
+	frame := append(header, payload...)
+	ni, err := DecodeNodeInfo(frame, "2.1")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if ni.GetNum() != orig.GetNum() || ni.GetUser().GetId() != "v21" {
+		t.Fatalf("unexpected result %+v", ni)
+	}
+}


### PR DESCRIPTION
## Summary
- support v2.1 frame markers in stripFrame
- allow DecodeNodeInfo/DecodeTelemetry/DecodeText to accept version "2.1"
- test framed v2.1 decoding for NodeInfo, Telemetry and text

## Testing
- `go test ./...`
- `go test ./decoder -run TestDecode -v`


------
https://chatgpt.com/codex/tasks/task_e_686bc319b5888323bb5139e0e9cb5356