### PR TITLE
Fix build error in meshspy

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -28,7 +28,6 @@ import (
 const (
 	welcomeMessage = "Ciao da MeshSpy, presto (spero) per tutti"
 	aliveMessage   = "MeshSpy Alive"
-
 )
 
 // Version of the MeshSpy program. This value can be overridden at build time
@@ -70,7 +69,7 @@ func main() {
 	}
 
 	if *msg != "" {
-		if err := mqtt.SendText(cfg.SerialPort, *dest, *msg); err != nil {
+		if err := serial.SendTextMessageTo(cfg.SerialPort, *dest, *msg); err != nil {
 			log.Fatalf("❌ Errore invio messaggio: %v", err)
 		}
 		log.Printf("✅ Messaggio inviato a %s", *dest)

--- a/serial/send.go
+++ b/serial/send.go
@@ -9,7 +9,17 @@ import (
 
 // SendTextMessage sends a text message to the primary channel via meshtastic-go.
 func SendTextMessage(port, text string) error {
-	cmd := exec.Command("/usr/local/bin/meshtastic-go", "--port", port, "message", "send", "-m", text)
+	return SendTextMessageTo(port, "", text)
+}
+
+// SendTextMessageTo sends a text message via meshtastic-go to the specified
+// destination node. If dest is empty the message is broadcast.
+func SendTextMessageTo(port, dest, text string) error {
+	args := []string{"--port", port, "message", "send", "-m", text}
+	if dest != "" {
+		args = append(args, "--dest", dest)
+	}
+	cmd := exec.Command("/usr/local/bin/meshtastic-go", args...)
 	log.Printf("\u2191 sending command: %s", strings.Join(cmd.Args, " "))
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/serial/send_test.go
+++ b/serial/send_test.go
@@ -28,3 +28,26 @@ func TestSendTextMessage(t *testing.T) {
 		t.Fatalf("unexpected args: got %q want %q", got, want)
 	}
 }
+
+func TestSendTextMessageTo(t *testing.T) {
+	scriptPath := "/usr/local/bin/meshtastic-go"
+	script := "#!/bin/sh\necho \"$@\" > /tmp/sendtext_args\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to create stub script: %v", err)
+	}
+	defer os.Remove(scriptPath)
+	defer os.Remove("/tmp/sendtext_args")
+
+	if err := SendTextMessageTo("ttyS1", "!abcd", "hello"); err != nil {
+		t.Fatalf("SendTextMessageTo returned error: %v", err)
+	}
+	data, err := os.ReadFile("/tmp/sendtext_args")
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	want := "--port ttyS1 message send -m hello --dest !abcd"
+	if got != want {
+		t.Fatalf("unexpected args: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add SendTextMessageTo for sending to a destination node
- fix build of `cmd/meshspy`
- test text send with optional destination

## Testing
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686bcfd30d748323ac607d21ef1b3739