### PR TITLE
Load MeshSpy version from .env.build

### DIFF
--- a/.env.build.example
+++ b/.env.build.example
@@ -4,3 +4,4 @@ DOCKER_PASSWORD=your-docker-token
 IMAGE=nicbad/meshspy
 TAG=latest
 MESHTASTIC_GO_VERSION=v0.2.4
+MESHSPY_VERSION=dev

--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/joho/godotenv" // ← aggiunto per leggere il file .env
+	"github.com/joho/godotenv" // ← per leggere i file .env
 
 	mqttpkg "meshspy/client"
 	"meshspy/config"
@@ -32,6 +32,17 @@ const (
 // Version of the MeshSpy program. This value can be overridden at build time
 // using: go build -ldflags="-X main.Version=x.y.z"
 var Version = "dev"
+
+func init() {
+	// Carica la versione dal file .env.build se presente
+	if err := godotenv.Load(".env.build"); err == nil {
+		if Version == "dev" {
+			if v := os.Getenv("MESHSPY_VERSION"); v != "" {
+				Version = v
+			}
+		}
+	}
+}
 
 func main() {
 	log.Println("🔥 MeshSpy avviamento iniziato...")


### PR DESCRIPTION
## Summary
- allow runtime version string to be set via `.env.build`
- document new `MESHSPY_VERSION` example variable

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686bc2bc3d9c8323964d482e733355b6