### PR TITLE
Add env-file usage to start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ the service is running and nodes are reached.
 ### `start_meshspy.sh` helper
 
 For a quick start, run the `start_meshspy.sh` script which launches the
-container with some default environment variables:
+container with some default environment variables. The script also loads
+additional settings from `.env.runtime` when present:
 
 - `SERIAL_PORT=/dev/ttyACM0`
 - `BAUD_RATE=115200`
@@ -129,7 +130,8 @@ in this database so that external tools can inspect the mesh topology.
 
 Owners of a Raspberry&nbsp;Pi&nbsp;5 can use the `start_berry5.sh` script. It
 launches the container for the arm64 architecture and stores the node database
-in the `meshspy_data` directory on the host.
+in the `meshspy_data` directory on the host. The helper also reads
+configuration from `.env.runtime` if available.
 
 Start it with the defaults:
 

--- a/start_berry5.sh
+++ b/start_berry5.sh
@@ -49,6 +49,7 @@ docker run -d \
   --privileged \
   -p 8080:8080 \
   -v ~/meshspy_data:/app/data \
+  --env-file .env.runtime \
   -e SERIAL_PORT=/dev/ttyACM0 \
   -e BAUD_RATE=115200 \
   -e MQTT_BROKER=tcp://smpisa.ddns.net:1883 \

--- a/start_meshspy.sh
+++ b/start_meshspy.sh
@@ -54,6 +54,7 @@ docker run -d \
   --privileged \
   -p 8080:8080 \
   -v ~/meshspy_data:/app/data \
+  --env-file .env.runtime \
   -e SERIAL_PORT=/dev/ttyACM0 \
   -e BAUD_RATE=115200 \
   -e MQTT_BROKER=tcp://smpisa.ddns.net:1883 \


### PR DESCRIPTION
## Summary
- load `.env.runtime` in `start_meshspy.sh` and `start_berry5.sh`
- document the new behaviour in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c469e3df88323a779fef83696782c