### PR TITLE
Show node locations on map

### DIFF
--- a/cmd/webapp/index.html
+++ b/cmd/webapp/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>MeshSpy Messages</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 <style>
 body {
   font-family: Arial, sans-serif;
@@ -66,6 +67,7 @@ button:hover {
 #defaultButton {
   margin-left: 10px;
 }
+#map { height: 400px; margin-top: 20px; }
 </style>
 </head>
 <body>
@@ -78,6 +80,7 @@ button:hover {
   <button type="submit">Send</button>
 </form>
 <button id="defaultButton" type="button">Send default</button>
+<div id="map"></div>
 <script>
 const ws = new WebSocket((location.protocol === "https:" ? "wss://" : "ws://") + location.host + "/ws");
 ws.onopen = () => console.log("WebSocket connection opened");
@@ -118,6 +121,28 @@ fetch("/nodes").then(r => r.json()).then(nodes => {
     list.appendChild(li);
   });
 });
+
+fetch("/positions").then(r => r.json()).then(pos => {
+  const map = L.map('map').setView([0,0], 2);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '© OpenStreetMap contributors'
+  }).addTo(map);
+  const byNode = {};
+  pos.forEach(p => {
+    const arr = byNode[p.NodeID] || [];
+    arr.push([p.Latitude, p.Longitude]);
+    byNode[p.NodeID] = arr;
+  });
+  Object.keys(byNode).forEach(id => {
+    const coords = byNode[id];
+    L.polyline(coords, {color: 'blue'}).addTo(map);
+    const last = coords[coords.length-1];
+    if (last) {
+      L.marker(last).addTo(map).bindPopup(id);
+    }
+  });
+});
 </script>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </body>
 </html>

--- a/cmd/webapp/main.go
+++ b/cmd/webapp/main.go
@@ -60,6 +60,17 @@ func main() {
 		json.NewEncoder(w).Encode(nodes)
 	})
 
+	http.HandleFunc("/positions", func(w http.ResponseWriter, r *http.Request) {
+		nodeID := r.URL.Query().Get("node")
+		pos, err := nodeStore.Positions(nodeID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(pos)
+	})
+
 	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {

--- a/mgmtapi/client.go
+++ b/mgmtapi/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	mqttpkg "meshspy/client"
+	"meshspy/storage"
 )
 
 // Client communicates with the management server HTTP API.
@@ -100,4 +101,28 @@ func (c *Client) ListNodes() ([]*mqttpkg.NodeInfo, error) {
 		return nil, err
 	}
 	return nodes, nil
+}
+
+// ListPositions retrieves node positions from the server.
+func (c *Client) ListPositions(nodeID string) ([]storage.NodePosition, error) {
+	if c == nil {
+		return nil, nil
+	}
+	url := c.baseURL + "/api/positions"
+	if nodeID != "" {
+		url += "?node=" + nodeID
+	}
+	resp, err := c.http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("server returned %s", resp.Status)
+	}
+	var pos []storage.NodePosition
+	if err := json.NewDecoder(resp.Body).Decode(&pos); err != nil {
+		return nil, err
+	}
+	return pos, nil
 }

--- a/storage/nodestore.go
+++ b/storage/nodestore.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"database/sql"
 	"encoding/json"
+	"time"
 
 	mqttpkg "meshspy/client"
 
@@ -12,6 +13,16 @@ import (
 // NodeStore manages persistent storage of NodeInfo records.
 type NodeStore struct {
 	db *sql.DB
+}
+
+// NodePosition represents a recorded position for a node.
+type NodePosition struct {
+	NodeID     string
+	Latitude   float64
+	Longitude  float64
+	Altitude   int
+	Time       int64
+	ReceivedAt time.Time
 }
 
 // NewNodeStore opens or creates a SQLite database at path and prepares the nodes table.
@@ -24,6 +35,17 @@ func NewNodeStore(path string) (*NodeStore, error) {
         id TEXT PRIMARY KEY,
         info TEXT,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )`); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS positions (
+        node_id TEXT,
+        latitude REAL,
+        longitude REAL,
+        altitude INTEGER,
+        time INTEGER,
+        received_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )`); err != nil {
 		db.Close()
 		return nil, err
@@ -45,7 +67,10 @@ func (s *NodeStore) Upsert(info *mqttpkg.NodeInfo) error {
 	_, err = s.db.Exec(`INSERT INTO nodes(id, info, updated_at) VALUES(?, ?, CURRENT_TIMESTAMP)
         ON CONFLICT(id) DO UPDATE SET info=excluded.info, updated_at=CURRENT_TIMESTAMP`,
 		info.ID, string(data))
-	return err
+	if err != nil {
+		return err
+	}
+	return s.addPosition(info)
 }
 
 // List returns all NodeInfo records stored in the database.
@@ -69,4 +94,43 @@ func (s *NodeStore) List() ([]*mqttpkg.NodeInfo, error) {
 		nodes = append(nodes, &n)
 	}
 	return nodes, rows.Err()
+}
+
+// addPosition stores the location from info if available.
+func (s *NodeStore) addPosition(info *mqttpkg.NodeInfo) error {
+	if info == nil {
+		return nil
+	}
+	if info.Latitude == 0 && info.Longitude == 0 {
+		return nil
+	}
+	_, err := s.db.Exec(`INSERT INTO positions(node_id, latitude, longitude, altitude, time, received_at)
+                VALUES(?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		info.ID, info.Latitude, info.Longitude, info.Altitude, info.LocationTime)
+	return err
+}
+
+// Positions returns recorded positions. When nodeID is empty all positions are returned.
+func (s *NodeStore) Positions(nodeID string) ([]NodePosition, error) {
+	var rows *sql.Rows
+	var err error
+	if nodeID == "" {
+		rows, err = s.db.Query(`SELECT node_id, latitude, longitude, altitude, time, received_at FROM positions ORDER BY received_at`)
+	} else {
+		rows, err = s.db.Query(`SELECT node_id, latitude, longitude, altitude, time, received_at FROM positions WHERE node_id = ? ORDER BY received_at`, nodeID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var positions []NodePosition
+	for rows.Next() {
+		var p NodePosition
+		if err := rows.Scan(&p.NodeID, &p.Latitude, &p.Longitude, &p.Altitude, &p.Time, &p.ReceivedAt); err != nil {
+			return nil, err
+		}
+		positions = append(positions, p)
+	}
+	return positions, rows.Err()
 }


### PR DESCRIPTION
## Summary
- track node positions in NodeStore and expose via `/positions`
- add API in management server and web UI for position list
- show markers and tracks on map using Leaflet

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686c4cc573c483238d4715e9d773fde9