### PR TITLE
Fix ResolveLong fallback to short name

### DIFF
--- a/nodemap/nodemap.go
+++ b/nodemap/nodemap.go
@@ -68,14 +68,20 @@ func (m *Map) Resolve(id string) string {
 	return id
 }
 
-// ResolveLong returns the long name for the given node id if known, otherwise
-// it falls back to the id itself.
+// ResolveLong returns the long name for the given node id when available.
+// If the long name is empty, it falls back to the short name and finally to
+// the id itself when no name is known.
 func (m *Map) ResolveLong(id string) string {
 	m.mu.RLock()
 	e, ok := m.nodes[id]
 	m.mu.RUnlock()
-	if ok && e.Long != "" {
-		return e.Long
+	if ok {
+		if e.Long != "" {
+			return e.Long
+		}
+		if e.Short != "" {
+			return e.Short
+		}
 	}
 	return id
 }

--- a/nodemap/nodemap_test.go
+++ b/nodemap/nodemap_test.go
@@ -34,3 +34,10 @@ func ExampleMap_List() {
 	// 0x1:Alice/A
 	// 0x2:Bob/B
 }
+
+func ExampleMap_ResolveLong_fallbackShort() {
+	nm := New()
+	nm.Update(0x1, "", "A")
+	fmt.Println(nm.ResolveLong("0x1"))
+	// Output: A
+}


### PR DESCRIPTION
## Summary
- show node short names when long name is absent
- add coverage for this behaviour

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c5606e7188323b68cdc8d90d1c735