### PR TITLE
Add telemetry node id support

### DIFF
--- a/client/proto_convert.go
+++ b/client/proto_convert.go
@@ -56,3 +56,25 @@ func NodeInfoFromMyInfo(mi *latestpb.MyNodeInfo) *NodeInfo {
 		Num: mi.GetMyNodeNum(),
 	}
 }
+
+// NodeInfoFromTelemetry converts telemetry metrics from a node into a partial
+// NodeInfo structure using the provided node number.
+func NodeInfoFromTelemetry(nodeNum uint32, tm *latestpb.Telemetry) *NodeInfo {
+	if tm == nil {
+		return nil
+	}
+	dm := tm.GetDeviceMetrics()
+	if dm == nil {
+		return nil
+	}
+	info := &NodeInfo{
+		ID:            fmt.Sprintf("0x%x", nodeNum),
+		Num:           nodeNum,
+		BatteryLevel:  int(dm.GetBatteryLevel()),
+		Voltage:       float64(dm.GetVoltage()),
+		ChannelUtil:   float64(dm.GetChannelUtilization()),
+		AirUtilTx:     float64(dm.GetAirUtilTx()),
+		UptimeSeconds: int(dm.GetUptimeSeconds()),
+	}
+	return info
+}

--- a/client/proto_convert.go
+++ b/client/proto_convert.go
@@ -78,3 +78,21 @@ func NodeInfoFromTelemetry(nodeNum uint32, tm *latestpb.Telemetry) *NodeInfo {
 	}
 	return info
 }
+
+// NodeInfoFromPosition converts a Position message into a partial NodeInfo
+// structure using the provided node number.
+func NodeInfoFromPosition(nodeNum uint32, pos *latestpb.Position) *NodeInfo {
+	if pos == nil {
+		return nil
+	}
+	info := &NodeInfo{
+		ID:             fmt.Sprintf("0x%x", nodeNum),
+		Num:            nodeNum,
+		Latitude:       float64(pos.GetLatitudeI()) / 1e7,
+		Longitude:      float64(pos.GetLongitudeI()) / 1e7,
+		Altitude:       int(pos.GetAltitude()),
+		LocationTime:   int64(pos.GetTime()),
+		LocationSource: pos.GetLocationSource().String(),
+	}
+	return info
+}

--- a/client/proto_convert_test.go
+++ b/client/proto_convert_test.go
@@ -120,3 +120,30 @@ func TestNodeInfoFromTelemetry(t *testing.T) {
 		t.Fatalf("float metrics mismatch: %+v", info)
 	}
 }
+
+func TestNodeInfoFromPosition(t *testing.T) {
+	pos := &pb.Position{
+		LatitudeI:      protoInt32(1234567),
+		LongitudeI:     protoInt32(-7654321),
+		Altitude:       protoInt32(100),
+		Time:           42,
+		LocationSource: pb.Position_LOC_INTERNAL,
+	}
+	info := NodeInfoFromPosition(0x99, pos)
+	if info == nil {
+		t.Fatal("nil info")
+	}
+	if info.ID != "0x99" || info.Num != 0x99 {
+		t.Fatalf("unexpected id: %+v", info)
+	}
+	if math.Abs(info.Latitude-float64(1234567)/1e7) > 1e-6 ||
+		math.Abs(info.Longitude-float64(-7654321)/1e7) > 1e-6 {
+		t.Fatalf("coords mismatch: %+v", info)
+	}
+	if info.LocationSource != pb.Position_LOC_INTERNAL.String() {
+		t.Fatalf("loc source mismatch: %s", info.LocationSource)
+	}
+	if info.Altitude != 100 || info.LocationTime != 42 {
+		t.Fatalf("alt/time mismatch: %+v", info)
+	}
+}

--- a/client/proto_convert_test.go
+++ b/client/proto_convert_test.go
@@ -95,3 +95,28 @@ func TestNodeInfoFromMyInfo(t *testing.T) {
 		t.Fatalf("unexpected result: %+v", info)
 	}
 }
+
+func TestNodeInfoFromTelemetry(t *testing.T) {
+	tm := &pb.Telemetry{
+		Variant: &pb.Telemetry_DeviceMetrics{DeviceMetrics: &pb.DeviceMetrics{
+			BatteryLevel:       protoUint32(50),
+			Voltage:            protoFloat32(3.7),
+			ChannelUtilization: protoFloat32(1.2),
+			AirUtilTx:          protoFloat32(0.5),
+			UptimeSeconds:      protoUint32(99),
+		}},
+	}
+	info := NodeInfoFromTelemetry(0x42, tm)
+	if info == nil {
+		t.Fatal("nil info")
+	}
+	if info.ID != "0x42" || info.Num != 0x42 {
+		t.Fatalf("unexpected id: %+v", info)
+	}
+	if info.BatteryLevel != 50 || info.UptimeSeconds != 99 {
+		t.Fatalf("metrics mismatch: %+v", info)
+	}
+	if math.Abs(info.Voltage-3.7) > 1e-6 || math.Abs(info.ChannelUtil-1.2) > 1e-6 {
+		t.Fatalf("float metrics mismatch: %+v", info)
+	}
+}

--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -264,6 +264,16 @@ func main() {
 					log.Printf("⚠️ invio info nodo al server: %v", err)
 				}
 			}
+		}, func(id uint32, pos *latestpb.Position) {
+			info := mqttpkg.NodeInfoFromPosition(id, pos)
+			if info != nil {
+				if err := nodeStore.Upsert(info); err != nil {
+					log.Printf("⚠️ aggiornamento db nodi: %v", err)
+				}
+				if err := mgmt.SendNode(info); err != nil {
+					log.Printf("⚠️ invio info nodo al server: %v", err)
+				}
+			}
 		}, nil, func(data string) {
 			// Publish every received message on the MQTT topic
 			token := client.Publish(cfg.MQTTTopic, 0, false, data)

--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -254,7 +254,17 @@ func main() {
 					log.Printf("⚠️ invio info nodo al server: %v", err)
 				}
 			}
-		}, nil, nil, func(data string) {
+		}, func(id uint32, tm *latestpb.Telemetry) {
+			info := mqttpkg.NodeInfoFromTelemetry(id, tm)
+			if info != nil {
+				if err := nodeStore.Upsert(info); err != nil {
+					log.Printf("⚠️ aggiornamento db nodi: %v", err)
+				}
+				if err := mgmt.SendNode(info); err != nil {
+					log.Printf("⚠️ invio info nodo al server: %v", err)
+				}
+			}
+		}, nil, func(data string) {
 			// Publish every received message on the MQTT topic
 			token := client.Publish(cfg.MQTTTopic, 0, false, data)
 			token.Wait()

--- a/decoder/messages.go
+++ b/decoder/messages.go
@@ -55,6 +55,40 @@ func DecodeTelemetry(data []byte, version string) (*latestpb.Telemetry, error) {
 	}
 }
 
+// DecodeTelemetryWithID decodes a telemetry packet and returns the sender node
+// id along with the Telemetry message. The id is zero when not present.
+func DecodeTelemetryWithID(data []byte, version string) (uint32, *latestpb.Telemetry, error) {
+	var err error
+	data, err = stripFrame(data)
+	if err != nil {
+		return 0, nil, err
+	}
+	switch version {
+	case "", "latest", "2.1":
+		var fr latestpb.FromRadio
+		if err := proto.Unmarshal(data, &fr); err == nil {
+			if pkt := fr.GetPacket(); pkt != nil {
+				from := pkt.GetFrom()
+				if dec := pkt.GetDecoded(); dec != nil {
+					if dec.GetPortnum() == latestpb.PortNum_TELEMETRY_APP {
+						var tm latestpb.Telemetry
+						if err := proto.Unmarshal(dec.GetPayload(), &tm); err == nil {
+							return from, &tm, nil
+						}
+					}
+				}
+			}
+		}
+		var tm latestpb.Telemetry
+		if err := proto.Unmarshal(data, &tm); err == nil && tm.GetVariant() != nil {
+			return 0, &tm, nil
+		}
+		return 0, nil, fmt.Errorf("not a Telemetry message")
+	default:
+		return 0, nil, fmt.Errorf("unsupported proto version: %s", version)
+	}
+}
+
 // DecodeText extracts a plain text message from the given data.
 func DecodeText(data []byte, version string) (string, error) {
 	var err error

--- a/decoder/messages_test.go
+++ b/decoder/messages_test.go
@@ -77,6 +77,31 @@ func TestDecodeTelemetry(t *testing.T) {
 	}
 }
 
+func TestDecodeTelemetryWithID(t *testing.T) {
+	tm := &pb.Telemetry{Time: 1, Variant: &pb.Telemetry_DeviceMetrics{DeviceMetrics: &pb.DeviceMetrics{}}}
+	payload, err := proto.Marshal(tm)
+	if err != nil {
+		t.Fatalf("marshal telemetry: %v", err)
+	}
+	d := &pb.Data{Portnum: pb.PortNum_TELEMETRY_APP, Payload: payload}
+	mp := &pb.MeshPacket{From: 0x42, PayloadVariant: &pb.MeshPacket_Decoded{Decoded: d}}
+	fr := &pb.FromRadio{PayloadVariant: &pb.FromRadio_Packet{Packet: mp}}
+	data, err := proto.Marshal(fr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	id, dec, err := DecodeTelemetryWithID(data, "latest")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != 0x42 {
+		t.Fatalf("unexpected id %x", id)
+	}
+	if dec.GetTime() != tm.GetTime() {
+		t.Fatalf("unexpected time %d", dec.GetTime())
+	}
+}
+
 func TestDecodeTelemetryFramedV21(t *testing.T) {
 	tm := &pb.Telemetry{
 		Time:    777,

--- a/serial/manager.go
+++ b/serial/manager.go
@@ -105,7 +105,7 @@ func (m *Manager) SendTextMessage(text string) error {
 func (m *Manager) ReadLoop(debug bool, protoVersion string, nm *nodemap.Map,
 	handleNodeInfo func(*latestpb.NodeInfo),
 	handleMyInfo func(*latestpb.MyNodeInfo),
-	handleTelemetry func(*latestpb.Telemetry),
+	handleTelemetry func(uint32, *latestpb.Telemetry),
 	handleText func(string),
 	publish func(string)) {
 

--- a/serial/manager.go
+++ b/serial/manager.go
@@ -106,9 +106,10 @@ func (m *Manager) ReadLoop(debug bool, protoVersion string, nm *nodemap.Map,
 	handleNodeInfo func(*latestpb.NodeInfo),
 	handleMyInfo func(*latestpb.MyNodeInfo),
 	handleTelemetry func(uint32, *latestpb.Telemetry),
+	handlePosition func(uint32, *latestpb.Position),
 	handleText func(string),
 	publish func(string)) {
 
 	readLoop(m.port, m.name, m.baud, debug, protoVersion, nm,
-		handleNodeInfo, handleMyInfo, handleTelemetry, handleText, publish)
+		handleNodeInfo, handleMyInfo, handleTelemetry, handlePosition, handleText, publish)
 }

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -62,6 +62,8 @@ func readLoop(port serial.Port, portName string, baud int, debug bool, protoVers
 	const (
 		start1    = 0x94
 		start2    = 0xC3
+		start1v21 = 0x44
+		start2v21 = 0x03
 		headerLen = 4
 		maxSize   = 512
 	)
@@ -149,7 +151,8 @@ func readLoop(port serial.Port, portName string, baud int, debug bool, protoVers
 			if len(buf) < 2 {
 				break
 			}
-			if buf[0] != start1 || buf[1] != start2 {
+			if (buf[0] != start1 || buf[1] != start2) &&
+				(buf[0] != start1v21 || buf[1] != start2v21) {
 				ch := buf[0]
 				buf = buf[1:]
 				if ch == '\n' {


### PR DESCRIPTION
## Summary
- decode telemetry packets with sender node id
- convert telemetry info to NodeInfo and persist
- handle telemetry updates in MeshSpy read loop
- update tests for telemetry node id decoding

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686c5d2b66248323b5c34609a34d5e5a