### PR TITLE
Enable MQTT resubscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ sends a `MeshSpy Alive` message on the configured MQTT topic and to the node
 itself using `meshtastic-go message send -m`, so other components can detect that
 the service is running and nodes are reached.
 
+The MQTT client automatically resumes subscriptions when the connection to the
+broker is restored.
+
 
 ### `start_meshspy.sh` helper
 

--- a/client/client.go
+++ b/client/client.go
@@ -102,7 +102,7 @@ func GetLocalNodeInfo(port string) (*NodeInfo, error) {
 				inNodeInfo = true
 				continue
 			} else {
-                                break // stop at the second node
+				break // stop at the second node
 			}
 		}
 
@@ -178,7 +178,8 @@ func ConnectMQTT(cfg config.Config) (mqtt.Client, error) {
 		SetClientID(cfg.ClientID).
 		SetAutoReconnect(true).
 		SetConnectRetry(true).
-		SetConnectRetryInterval(5 * time.Second)
+		SetConnectRetryInterval(5 * time.Second).
+		SetResumeSubs(true)
 
 	if cfg.User != "" {
 		opts.SetUsername(cfg.User)


### PR DESCRIPTION
## Summary
- reconnect MQTT subscriptions automatically with `SetResumeSubs(true)`
- document auto-resubscription behavior in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c62e7dae083238c9365928b30c994