### PR TITLE
Add waypoint, admin and alert message decoding

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -254,7 +254,7 @@ func main() {
 					log.Printf("⚠️ invio info nodo al server: %v", err)
 				}
 			}
-		}, nil, nil, func(data string) {
+		}, nil, nil, nil, nil, nil, func(data string) {
 			// Publish every received message on the MQTT topic
 			token := client.Publish(cfg.MQTTTopic, 0, false, data)
 			token.Wait()

--- a/serial/manager.go
+++ b/serial/manager.go
@@ -106,9 +106,12 @@ func (m *Manager) ReadLoop(debug bool, protoVersion string, nm *nodemap.Map,
 	handleNodeInfo func(*latestpb.NodeInfo),
 	handleMyInfo func(*latestpb.MyNodeInfo),
 	handleTelemetry func(*latestpb.Telemetry),
+	handleWaypoint func(*latestpb.Waypoint),
+	handleAdmin func([]byte),
+	handleAlert func(string),
 	handleText func(string),
 	publish func(string)) {
 
 	readLoop(m.port, m.name, m.baud, debug, protoVersion, nm,
-		handleNodeInfo, handleMyInfo, handleTelemetry, handleText, publish)
+		handleNodeInfo, handleMyInfo, handleTelemetry, handleWaypoint, handleAdmin, handleAlert, handleText, publish)
 }


### PR DESCRIPTION
## Summary
- implement decoding functions for WAYPOINT_APP, ADMIN_APP and ALERT_APP
- call new handlers for waypoint, admin and alert packets in serial read loop
- extend serial manager and main program for additional callbacks
- test decoding logic for the new message types

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686c61c484a483238cb91c28f68818a8