### PR TITLE
Fix MQTT creds from env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ additional settings from `.env.runtime` when present:
 - `MQTT_TOPIC=meshspy`
 -  (avoid wildcards here, as publishing to topics like `mesh/#` is not supported)
 - `MQTT_CLIENT_ID=meshspy-kali`
-- `MQTT_USER=testmeshspy`
-- `MQTT_PASS=test1`
+- `MQTT_USER` and `MQTT_PASS` can be set in `.env.runtime` when the broker requires authentication
 - `SEND_ALIVE_ON_START=true`
   (set to `false` if you do **not** want the service to send and log a `MeshSpy Alive`
   message on start-up)

--- a/start_berry5.sh
+++ b/start_berry5.sh
@@ -55,8 +55,6 @@ docker run -d \
   -e MQTT_BROKER=tcp://smpisa.ddns.net:1883 \
   -e MQTT_TOPIC=meshspy \
   -e MQTT_CLIENT_ID=meshspy-berry5 \
-  -e MQTT_USER="testmeshspy" \
-  -e MQTT_PASS="test1" \
   -e SEND_ALIVE_ON_START=true \
   -e NODE_DB_PATH=/app/data/nodes.db \
   $IMAGE_NAME

--- a/start_meshspy.sh
+++ b/start_meshspy.sh
@@ -60,8 +60,6 @@ docker run -d \
   -e MQTT_BROKER=tcp://smpisa.ddns.net:1883 \
   -e MQTT_TOPIC=meshspy \
   -e MQTT_CLIENT_ID=meshspy-kali \
-  -e MQTT_USER="testmeshspy" \
-  -e MQTT_PASS="test1" \
   -e SEND_ALIVE_ON_START=true \
   $IMAGE_NAME
 


### PR DESCRIPTION
## Summary
- fix start_meshspy.sh and start_berry5.sh so mqtt credentials come from `.env.runtime`
- clarify README about setting `MQTT_USER` and `MQTT_PASS`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686cbbf1396c8323b6536f9e7be6afde