### PR TITLE
Add telemetry database support

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -254,7 +254,11 @@ func main() {
 					log.Printf("⚠️ invio info nodo al server: %v", err)
 				}
 			}
-		}, nil, nil, nil, nil, nil, func(data string) {
+		}, func(tel *latestpb.Telemetry) {
+			if err := nodeStore.AddTelemetry(tel); err != nil {
+				log.Printf("⚠️ salvataggio telemetry: %v", err)
+			}
+		}, nil, nil, nil, nil, func(data string) {
 			// Publish every received message on the MQTT topic
 			token := client.Publish(cfg.MQTTTopic, 0, false, data)
 			token.Wait()


### PR DESCRIPTION
## Summary
- store telemetry data in a new `telemetry` table
- expose `AddTelemetry` and `Telemetry` on `NodeStore`
- persist telemetry received on the serial port
- test telemetry storage

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686cbd11b7f883239d793d47b3bef46d