### PR TITLE
Ensure NodeStore directory is created automatically

### DIFF
--- a/storage/nodestore.go
+++ b/storage/nodestore.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"database/sql"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"time"
 
 	mqttpkg "meshspy/client"
@@ -27,6 +29,9 @@ type NodePosition struct {
 
 // NewNodeStore opens or creates a SQLite database at path and prepares the nodes table.
 func NewNodeStore(path string) (*NodeStore, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
 		return nil, err

--- a/storage/nodestore_test.go
+++ b/storage/nodestore_test.go
@@ -24,6 +24,27 @@ func TestNewNodeStore(t *testing.T) {
 	}
 }
 
+// TestNewNodeStoreCreatesDir ensures the database directory is created when
+// it does not already exist. NODE_DB_PATH is used to simulate the value passed
+// from the application.
+func TestNewNodeStoreCreatesDir(t *testing.T) {
+	base := t.TempDir()
+	dbPath := filepath.Join(base, "sub", "nodes.db")
+	if err := os.Setenv("NODE_DB_PATH", dbPath); err != nil {
+		t.Fatalf("Setenv returned error: %v", err)
+	}
+	defer os.Unsetenv("NODE_DB_PATH")
+
+	ns, err := NewNodeStore(os.Getenv("NODE_DB_PATH"))
+	if err != nil {
+		t.Fatalf("NewNodeStore returned error: %v", err)
+	}
+	ns.Close()
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("database file not created: %v", err)
+	}
+}
+
 func TestNodeStoreUpsertAndList(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "nodes.db")


### PR DESCRIPTION
## Summary
- make `storage.NewNodeStore` create the parent directory before opening the DB
- add unit test to ensure creation succeeds when the directory does not already exist

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686cbd11be70832396663b3669671ee9