### PR TITLE
Retry waiting for serial port

### DIFF
--- a/cmd/meshspy/main.go
+++ b/cmd/meshspy/main.go
@@ -159,8 +159,12 @@ func main() {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	// 📡 Wait for the serial port to be available before running meshtastic-go
-	if err := serial.WaitForSerial(cfg.SerialPort, 30*time.Second); err != nil {
-		log.Fatalf("❌ Porta seriale %s non disponibile: %v", cfg.SerialPort, err)
+	for attempt := 1; ; attempt++ {
+		if err := serial.WaitForSerial(cfg.SerialPort, 30*time.Second); err == nil {
+			break
+		} else {
+			log.Printf("❌ Porta seriale %s non disponibile: %v (tentativo %d)", cfg.SerialPort, err, attempt)
+		}
 	}
 
 	// Send an Alive message to the node if requested


### PR DESCRIPTION
## Summary
- keep waiting for the serial port before starting MeshSpy

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686ce23d0dbc832388bd768050261c20